### PR TITLE
Add set-env input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: Bot slug name (GitHub App name)
     required: false
     default: github-actions
+  set-env:
+    description: "Save action's output also as environment variables"
+    type: bool
+    default: true
   env-prefix:
     description: Prefix for environment variables
     required: false
@@ -56,11 +60,14 @@ runs:
           const botName = `${botSlugName}[bot]`
 
           let envPrefix = core.getInput('env_prefix', { required: false })
-          if (envPrefix) {
-            envPrefix = envPrefix.replace(/[^a-z0-9]/gi, '').toUpperCase()
-            envPrefix = `${envPrefix}__`
+          let setEnv = core.getBooleanInput('set_env') || false
+          if (setEnv) {
+            if (envPrefix) {
+              envPrefix = envPrefix.replace(/[^a-z0-9]/gi, '').toUpperCase()
+              envPrefix = `${envPrefix}__`
+            }
+            core.debug(`envPrefix: ${envPrefix}`)
           }
-          core.debug(`envPrefix: ${envPrefix}`)
 
           const { data } = await github.rest.users.getByUsername({
             username: botName
@@ -74,31 +81,32 @@ runs:
 
           core.debug(`botId: ${botId}`)
           core.setOutput('id', botId)
-          core.exportVariable(`${envPrefix}BOT_ID`, botId)
+          setEnv && core.exportVariable(`${envPrefix}BOT_ID`, botId)
 
           core.debug(`botSlugName: ${botSlugName}`)
           core.setOutput('slug', botSlugName)
-          core.exportVariable(`${envPrefix}BOT_SLUG`, botSlugName)
+          setEnv && core.exportVariable(`${envPrefix}BOT_SLUG`, botSlugName)
 
           core.debug(`botName: ${botName}`)
           core.setOutput('name', `${botName}`)
-          core.exportVariable(`${envPrefix}BOT_NAME`, botName)
+          setEnv && core.exportVariable(`${envPrefix}BOT_NAME`, botName)
 
           core.debug(`botEmail: ${botEmail}`)
           core.setOutput('email', `${botEmail}`)
-          core.exportVariable(`${envPrefix}BOT_EMAIL`, botEmail)
+          setEnv && core.exportVariable(`${envPrefix}BOT_EMAIL`, botEmail)
 
           core.debug(`botNameEmail: ${botNameEmail}`)
           core.setOutput('name_email', `${botNameEmail}`)
-          core.exportVariable(`${envPrefix}BOT_NAME_EMAIL`, botNameEmail)
+          setEnv && core.exportVariable(`${envPrefix}BOT_NAME_EMAIL`, botNameEmail)
 
           core.debug(`botHtmlUrl: ${botHtmlUrl}`)
           core.setOutput('html_url', `${botHtmlUrl}`)
-          core.exportVariable(`${envPrefix}BOT_HTML_URL`, botHtmlUrl)
+          setEnv && core.exportVariable(`${envPrefix}BOT_HTML_URL`, botHtmlUrl)
 
           core.debug(`botApiUrl: ${botApiUrl}`)
           core.setOutput('api_url', `${botApiUrl}`)
-          core.exportVariable(`${envPrefix}BOT_API_URL`, botApiUrl)
+          setEnv && core.exportVariable(`${envPrefix}BOT_API_URL`, botApiUrl)
       env:
         INPUT_BOT_SLUG_NAME: ${{ inputs.bot-slug-name }}
+        INPUT_SET_ENV: ${{ inputs.set-env }}
         INPUT_ENV_PREFIX: ${{ inputs.env-prefix }}


### PR DESCRIPTION
This is first in a series of small patches.

This one introduces new boolean input `set-env`. If true, it stops the env vars from being exported. This is a backwards compatible non-breaking change.