### PR TITLE
ci.yml: Use boolean for debug input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,10 @@ on:
   workflow_dispatch:
     inputs:
       debug:
-        type: choice
         description: Debug mode
         required: false
-        options:
-          - 'true'
-          - 'false'
+        type: boolean
+        default: true
 
 # Allow one concurrent
 concurrency:


### PR DESCRIPTION
This is just a tiny fix that converts the boolean `choice` input into a proper `boolean` type.